### PR TITLE
Fix player Attack ZOffset

### DIFF
--- a/zscript/player.txt
+++ b/zscript/player.txt
@@ -33,6 +33,7 @@ class NTM_Player : DoomPlayer {
 		Player.WeaponSlot 7, "BFG9000", "NTM_BFG9000";
 		Player.CrouchSprite "NPLC";
 		Player.ViewHeight 46;
+		Player.AttackZOffset 18;
 		Scale 0.666;
 	}
 	


### PR DESCRIPTION
Fixes an issue with the alignment of the player attack and the camera.

Player attack before fix:
![NTMAI_zoffest](https://user-images.githubusercontent.com/72579524/218799984-b8cc2edb-4453-4265-a166-6a6aa2c5486b.PNG)

And after the fix:
![NTMAI_fixed](https://user-images.githubusercontent.com/72579524/218800018-a87a8276-3a58-4973-8a9b-3e7fc47705a6.PNG)

I believe this is due to the player height being changed.